### PR TITLE
Fix build error by grouping the jsx expressions inside parent container

### DIFF
--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -3,9 +3,8 @@ import { Head } from '@inertiajs/react';
 
 export default function Dashboard({ auth }) {
     return (
-
+        <>
             <Head title="Dashboard" />
-
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
@@ -13,6 +12,6 @@ export default function Dashboard({ auth }) {
                     </div>
                 </div>
             </div>
-
+        </>
     );
 }


### PR DESCRIPTION
fix error occuring when trying to run npm run build:

jsx expressions in dashboard.jsx file were not grouped inside a parent container => fixed by wrapping them inside fragment component